### PR TITLE
chore(*): update release version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-slack-notify",
-  "version": "1.0.4",
+  "version": "1.3.1",
   "description": "Slack notification action that just works",
   "author": "The Actions Org",
   "license": "MIT",


### PR DESCRIPTION
Created the initial release (`v1.3.0`) as a minor step ahead of the archived action's [latest version](https://github.com/adamkdean/simple-slack-notify/releases/tag/v1.1.2). With that, I forgot to update the `package.json`. Here it is (as `v1.3.1`) 🙌🏻 